### PR TITLE
Refactor GitHub client authentication in find-organization-packages w…

### DIFF
--- a/.github/workflows/find-organization-packages.yml
+++ b/.github/workflows/find-organization-packages.yml
@@ -71,23 +71,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check gh client auth status for FROM_ORG_PAT secret by saving output to file and post the file as a comment
-        run: |
-          gh auth status > gh-auth-status.txt
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          gh issue comment ${{ github.event.issue.number }} --body-file gh-auth-status.txt
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.FROM_ORG_PAT }}
+      # - name: Check gh client auth status for FROM_ORG_PAT secret by saving output to file and post the file as a comment
+      #   run: |
+      #     gh auth status > gh-auth-status.txt
+      #     GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+      #     gh issue comment ${{ github.event.issue.number }} --body-file gh-auth-status.txt
+      #   shell: bash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.FROM_ORG_PAT }}
 
-      - name: Check gh client auth status for TO_ORG_PAT secret by saving output to file and post the file as a comment
-        run: |
-          gh auth status > gh-auth-status.txt
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          gh issue comment ${{ github.event.issue.number }} --body-file gh-auth-status.txt
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.TO_ORG_PAT }}
+      # - name: Check gh client auth status for TO_ORG_PAT secret by saving output to file and post the file as a comment
+      #   run: |
+      #     gh auth status > gh-auth-status.txt
+      #     GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+      #     gh issue comment ${{ github.event.issue.number }} --body-file gh-auth-status.txt
+      #   shell: bash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.TO_ORG_PAT }}
 
       - name: Change label to migration-checked, and remove in-progress
         run: |


### PR DESCRIPTION
This pull request involves changes to the GitHub Actions workflow for the `find-organization-packages` job in the `.github/workflows/find-organization-packages.yml` file. The primary change is the commenting out of steps that check the GitHub client authentication status for `FROM_ORG_PAT` and `TO_ORG_PAT` secrets.